### PR TITLE
fix: 评论者ip是ipv6时，在php81和typecho 1.2 评论界面报错

### DIFF
--- a/libs/IP.php
+++ b/libs/IP.php
@@ -79,8 +79,8 @@ class IPLocation_IP
     {
         $addresses = IPLocation_IP::find($ip);
         $address = 'unknown';
-
-        if (!empty($addresses)) {
+        
+        if (!empty($addresses) && $addresses!= 'N/A') {
             $addresses = array_unique($addresses);
             $address = implode('', $addresses);
         }


### PR DESCRIPTION
当评论者ip地址是ipv6时，默认返回的是'N/A'，此时不是一个数组，在php8环境上会报以下错误：

```txt
array_unique(): Argument #1 ($array) must be of type array, string given
```
目前的修复方式是暂时先判断返回值是不是‘N/A',再去对IP做处理